### PR TITLE
Quick update for small zuse library changes.

### DIFF
--- a/app/string-tester.hoon
+++ b/app/string-tester.hoon
@@ -1,7 +1,7 @@
 ::  Primitive tester for the String library.
 /+  string
 !:
-|_  {bowl $~}
+|_  {bowl:gall $~}
 
 ++  poke-noun
   |=  *

--- a/lib/string.hoon
+++ b/lib/string.hoon
@@ -169,7 +169,7 @@
 ++  trim-left
   |=  str/tape
   ^-  tape
-  (scan str ;~(pfix spac:poja (star next)))
+  (scan str ;~(pfix spac:de-json:html (star next)))
 ::
 ::  Trim whitespace off string right-side.
 ++  trim-right


### PR DESCRIPTION
## Why?
I was away from urbit for a long while and when I came back I wanted to try out some of my old code. It depended on this string library so I tried to load it but it didn't work. :(

## What Changed?
Update 2 calls to zuse cores (?) that had changed.

## Discussion / Considerations
None

## QA / User Acceptance
```
> |start %string-tester
>=
%sum
%tail
%get
%starts-with
%ends-with
%contains
%contains-any
%contains-all
%find-last
%find-nth
%find-first-any
%find-last-any
%trim-left
%trim-right
%trim
%delete
%delete-first
%delete-last
%delete-nth
%delete-all
%replace
%replace-first
%replace-last
%replace-nth
%replace-all
%split
%glue
[%all-passed "(:"]
> :string-tester test
```